### PR TITLE
Made translatable texts. Replace $this to $block.

### DIFF
--- a/view/frontend/templates/ratings/view.phtml
+++ b/view/frontend/templates/ratings/view.phtml
@@ -1,11 +1,11 @@
-<?php if ($this->getLsProductAttrs()) { ?>
-    <div class="product-reviews-summary <?php echo $this->getIsShortType() ? 'short ' : '' ?>mg-lipscore-rating-wrapper">
+<?php if ($block->getLsProductAttrs()) { ?>
+    <div class="product-reviews-summary <?php echo $block->getIsShortType() ? 'short ' : '' ?>mg-lipscore-rating-wrapper">
         <div class="rating-summary">
-            <div <?php echo $this->getRatingType() ?>
-                 <?php echo $this->getLsProductAttrs() ?>>
+            <div <?php echo $block->getRatingType() ?>
+                 <?php echo $block->getLsProductAttrs() ?>>
             </div>
         </div>
      </div>
 <?php } else { ?>
-    <div style="display: none !important;">Lipscore: empty product data</div>
+    <div style="display: none !important;"><?php echo $block->escapeHtml(__('Lipscore: empty product data')) ?></div>
 <?php } ?>

--- a/view/frontend/templates/reviews/title.phtml
+++ b/view/frontend/templates/reviews/title.phtml
@@ -1,3 +1,3 @@
 <span id='js-lipscore-reviews-tab'>
-    <?php echo __('Reviews') ?><span id='js-lipscore-reviews-tab-count' style='display: none;'>&nbsp;(<span class='lipscore-review-count' <?php echo $this->getLsProductAttrs() ?>></span>)</span>
+    <?php echo $block->escapeHtml(__('Reviews')) ?><span id='js-lipscore-reviews-tab-count' style='display: none;'>&nbsp;(<span class='lipscore-review-count' <?php echo $block->getLsProductAttrs() ?>></span>)</span>
 </span>

--- a/view/frontend/templates/reviews/view.phtml
+++ b/view/frontend/templates/reviews/view.phtml
@@ -1,7 +1,7 @@
-<div style="display: none !important;">Reviews</div>
+<div style="display: none !important;"><?php echo $block->escapeHtml(__('Reviews')) ?></div>
 <?php if ($this->getLsProductAttrs()) { ?>
-    <div id="lipscore-review-post" <?php echo $this->getLsProductAttrs() ?>></div>
-    <div id="lipscore-review-list" <?php echo $this->getLsProductAttrs() ?>></div>
+    <div id="lipscore-review-post" <?php echo $block->getLsProductAttrs() ?>></div>
+    <div id="lipscore-review-list" <?php echo $block->getLsProductAttrs() ?>></div>
 <?php } else { ?>
-    <div style="display: none !important;">Lipscore: empty product data</div>
+    <div style="display: none !important;"><?php echo $block->escapeHtml(__('Lipscore: empty product data')) ?></div>
 <?php } ?>

--- a/view/frontend/templates/reviews/view_single.phtml
+++ b/view/frontend/templates/reviews/view_single.phtml
@@ -1,4 +1,4 @@
 <div class="lipscore-reviews-single">
-    <h2><?php echo $this->getLayout()->createBlock('Lipscore\RatingsReviews\Block\Product\Review\Title')->toHtml() ?></h2>
-    <?php echo $this->getLayout()->createBlock('Lipscore\RatingsReviews\Block\Product\Review')->toHtml() ?>
+    <h2><?php echo $block->getLayout()->createBlock(\Lipscore\RatingsReviews\Block\Product\Review\Title::class)->toHtml() ?></h2>
+    <?php echo $block->getLayout()->createBlock(\Lipscore\RatingsReviews\Block\Product\Review::class)->toHtml() ?>
 </div>


### PR DESCRIPTION
Fixes for templates and use Magento guide lines:
 - Translate texts and use escapeHtml
 - Replace $this to $block
 - Replace string class names to declarative names 