### PR TITLE
CSP Whitelist support in module.

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="font-src">
+            <values>
+                <value id="lipscore" type="host">static.lipscore.com</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="lipscore" type="host">static.lipscore.com</value>
+            </values>
+        </policy>
+        <policy id="style-src">
+            <values>
+                <value id="lipscore" type="host">static.lipscore.com</value>
+            </values>
+        </policy>
+        <policy id="script-src">
+            <values>
+                <value id="lipscore" type="host">static.lipscore.com</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="lipscore" type="host">wapi.lipscore.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
Hi!

Magento introduces Content Security Policies(SSP) Whitelist feature in Magento since 2.3.5 and it requires add additional CSP Configuration in module.
More details here https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/content-security-policies.html.

Based on installed version and review report added Lipscore domains to whitelists:
- font-src
- img-src
- style-src
- script-src
- connect-src

Please review, 