### PR TITLE
Add support for select in Brand attribute

### DIFF
--- a/Model/System/Config/Source/Product/Brand.php
+++ b/Model/System/Config/Source/Product/Brand.php
@@ -2,7 +2,7 @@
 
 namespace Lipscore\RatingsReviews\Model\System\Config\Source\Product;
 
-use \Magento\Framework\Data\Collection;
+use Magento\Framework\Data\Collection;
 use Magento\Catalog\Model\Product;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory as AttributeCollectionFactory;
 use Magento\Eav\Model\Entity\Type;
@@ -31,13 +31,13 @@ class Brand implements \Magento\Framework\Option\ArrayInterface
      * @param Type $type
      */
     public function __construct(
-        Logger $logger,
-        AttributeCollectionFactory $attributeFactory,
-        Type $type
+        \Lipscore\RatingsReviews\Model\Logger $logger,
+        \Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory $attributeFactory,
+        \Magento\Eav\Model\Entity\Type $type
     ) {
-        $this->logger = $logger;
+        $this->logger           = $logger;
         $this->attributeFactory = $attributeFactory;
-        $this->type = $type;
+        $this->type             = $type;
     }
 
     /**

--- a/Model/System/Config/Source/Product/Brand.php
+++ b/Model/System/Config/Source/Product/Brand.php
@@ -4,31 +4,28 @@ namespace Lipscore\RatingsReviews\Model\System\Config\Source\Product;
 
 use Magento\Framework\Data\Collection;
 use Magento\Catalog\Model\Product;
-use Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory as AttributeCollectionFactory;
-use Magento\Eav\Model\Entity\Type;
-use Lipscore\RatingsReviews\Model\Logger;
 
 class Brand implements \Magento\Framework\Option\ArrayInterface
 {
     /**
-     * @var AttributeCollectionFactory
+     * @var \Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory
      */
     protected $attributeFactory;
 
     /**
-     * @var Type
+     * @var \Magento\Eav\Model\Entity\Type
      */
     protected $type;
 
     /**
-     * @var Logger
+     * @var \Lipscore\RatingsReviews\Model\Logger
      */
     protected $logger;
 
     /**
-     * @param Logger $logger
-     * @param AttributeCollectionFactory $attributeFactory
-     * @param Type $type
+     * @param \Lipscore\RatingsReviews\Model\Logger $logger
+     * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory $attributeFactory
+     * @param \Magento\Eav\Model\Entity\Type $type
      */
     public function __construct(
         \Lipscore\RatingsReviews\Model\Logger $logger,
@@ -66,6 +63,11 @@ class Brand implements \Magento\Framework\Option\ArrayInterface
         return $options;
     }
 
+     /**
+     * Find attributes to render
+     * 
+     * @return array
+     */
     protected function findAttrs()
     {
         $attrs = [];


### PR DESCRIPTION
Add full support for `select` attributes in Brand attribute. Now it doesn't work. Query is bugged and it doesn't support `int` which are the most popular backend type for select. Tested on Magento 2.4.3